### PR TITLE
bmdef.h: If NCBI_SSE is defined, define BMSSE*OPT accordingly.

### DIFF
--- a/src/bmdef.h
+++ b/src/bmdef.h
@@ -29,7 +29,7 @@
 #      define BMSSE2OPT 1
 #    endif
 #    if NCBI_SSE >= 40
-#      define BMSSE4OPT 1
+#      define BMSSE2OPT 1
 #    endif
 #    if NCBI_SSE >= 42
 #      define BMSSE42OPT 1

--- a/src/bmdef.h
+++ b/src/bmdef.h
@@ -23,6 +23,18 @@
 #    define BM_HASFORCEINLINE
 #    define BMFORCEINLINE NCBI_FORCEINLINE
 #  endif
+
+#  ifdef NCBI_SSE
+#    if NCBI_SSE >= 20
+#      define BMSSE2OPT 1
+#    endif
+#    if NCBI_SSE >= 40
+#      define BMSSE4OPT 1
+#    endif
+#    if NCBI_SSE >= 42
+#      define BMSSE42OPT 1
+#    endif
+#  endif
 #endif
 
 


### PR DESCRIPTION
I'll introduce this macro shortly per https://jira.ncbi.nlm.nih.gov/browse/CXX-9614.