### PR TITLE
bmdef.h: Make BMNOEXEPT empty under Microsoft Visual Studio 2013.

### DIFF
--- a/src/bmdef.h
+++ b/src/bmdef.h
@@ -55,7 +55,7 @@
 
 // cxx11 features
 //
-#ifdef BM_NO_CXX11
+#if defined(BM_NO_CXX11)  ||  (defined(_MSC_VER)  &&  _MSC_VER < 1900)
 # define BMNOEXEPT
 #else
 # ifndef BMNOEXEPT


### PR DESCRIPTION
This compiler is only partially C++11 compliant, supporting move
constructors (and a number of other C++11-isms) but not noexcept.