### PR TITLE
bmfunc.h (word_bitcount64): Conditionalize _mm_popcnt_u64 on BM64OPT.

### DIFF
--- a/src/bmfunc.h
+++ b/src/bmfunc.h
@@ -154,7 +154,11 @@ BMFORCEINLINE
 int word_bitcount64(bm::id64_t x)
 {
 #if defined(BMSSE42OPT) || defined(BMAVX2OPT)
+#  ifdef BM64OPT
     return (int)_mm_popcnt_u64(x);
+#  else
+    return _mm_popcnt_u32(x >> 32) + _mm_popcnt_u32(x & 0xFFFFFFFFUL);
+#  endif
 #else
     x = x - ((x >> 1) & 0x5555555555555555);
     x = (x & 0x3333333333333333) + ((x >> 2) & 0x3333333333333333);


### PR DESCRIPTION
On 32-bit x86 builds with SSE 4.2 enabled, work around the
unavailability of _mm_popcnt_u64 by obtaining and adding
_mm_popcnt_u32 values for the argument's upper and lower 32 bits.