### PR TITLE
bmutil.h: #include <emmintrin.h> as needed for __m128i.

### DIFF
--- a/src/bmutil.h
+++ b/src/bmutil.h
@@ -27,6 +27,8 @@ For more information please visit:  http://bitmagic.io
 
 #if defined(_M_AMD64) || defined(_M_X64) 
 #include <intrin.h>
+#elif defined(BMSSE2OPT) || defined(BMSSE42OPT)
+#include <emmintrin.h>
 #endif
 
 #ifdef __GNUG__


### PR DESCRIPTION
This patch addresses an immediate problem on macOS.  I suspect you'll likewise want a conditional #include directive of <avx2intrin.h> for __m256i when BMAVX2OPT is defined.