### PR TITLE
gap_transpose_engine::tmatrix_type: Explicitly static_cast matrix dimensions.

### DIFF
--- a/src/bmdef.h
+++ b/src/bmdef.h
@@ -389,17 +389,18 @@ For more information please visit:  http://bitmagic.io
 #endif
 
 
-#ifdef __GNUG__
-#ifndef __clang__
-
-#if __GNUC__ > 6 
-#  define BM_FALLTHROUGH __attribute__ ((fallthrough))
-#else
-# define BM_FALLTHROUGH
-#endif
-#else
-#  define BM_FALLTHROUGH [[clang::fallthrough]]
-#endif
+#if __cplusplus >= 201703L
+#  define BM_FALLTHROUGH [[fallthrough]]
+#elif defined(__clang__)
+#  if __cplusplus >= 201103L
+#    define BM_FALLTHROUGH [[clang::fallthrough]]
+#  endif
+#elif defined(__GNUG__)  &&  __GNUC__ >= 7
+#  if __cplusplus >= 201103L
+#    define BM_FALLTHROUGH [[gcc::fallthrough]]
+#  else
+#    define BM_FALLTHROUGH __attribute__ ((fallthrough))
+#  endif
 #else
 #  define BM_FALLTHROUGH
 #endif

--- a/src/bmdef.h
+++ b/src/bmdef.h
@@ -401,11 +401,11 @@ For more information please visit:  http://bitmagic.io
 #  else
 #    define BM_FALLTHROUGH __attribute__ ((fallthrough))
 #  endif
-#else
-#  define BM_FALLTHROUGH
 #endif
 
-
+#ifndef BM_FALLTHROUGH
+#  define BM_FALLTHROUGH
+#endif
 
 #endif
 

--- a/src/bmtrans.h
+++ b/src/bmtrans.h
@@ -748,8 +748,9 @@ public:
     ///
     /// matrix[size_of_gap*8][(Size_block_in_bytes / size_of_gap) / number_of_planes)] 
     typedef 
-    tmatrix<GT, sizeof(GT)*8, 
-                (((BLOCK_SIZE * sizeof(unsigned)) / (sizeof(GT))) / (sizeof(GT) * 8))>
+    tmatrix<GT, static_cast<unsigned>(sizeof(GT)*8),
+            static_cast<unsigned>(((BLOCK_SIZE * sizeof(unsigned)) / (sizeof(GT)))
+                                  / (sizeof(GT) * 8))>
                 tmatrix_type;
                 
     gap_transpose_engine() : eff_cols_(0)


### PR DESCRIPTION
Address warnings observed with gcc -Wconversion.

(Yes, the type of an integer division's divisor formally affects the result type, I suppose for uniformity's sake.)