### PR TITLE
base_sparse_vector::plain: Correct const variant's return type.

### DIFF
--- a/src/bmbmatrix.h
+++ b/src/bmbmatrix.h
@@ -370,7 +370,7 @@ public:
         \brief get access to bit-plain as is (can return NULL)
     */
     bvector_type_ptr plain(unsigned i) { return bmatr_.get_row(i); }
-    const bvector_type_ptr plain(unsigned i) const { return bmatr_.get_row(i); }
+    bvector_type_const_ptr plain(unsigned i) const { return bmatr_.get_row(i); }
 
     bvector_type* get_null_bvect() { return bmatr_.get_row(this->null_plain());}
 


### PR DESCRIPTION
Return `bvector_type_const_ptr`, not `const bvector_type_ptr`, in which
the `const` had no effect due to applying at the wrong level.

Preemptively address a warning (with `-Wignored-qualifiers`) that's otherwise likely to break gbench builds using `-Werror`.

BTW, I suspect you meant "plane" throughout, but that may not be worth correcting at this point.