### PR TITLE
BM_FALLTHROUGH: Blacklist [[fallthrough]] in a Clang corner case.

### DIFF
--- a/src/bmdef.h
+++ b/src/bmdef.h
@@ -408,7 +408,8 @@ For more information please visit:  http://bitmagic.io
 #ifndef __has_attribute
 #  define __has_attribute(x) 0
 #endif
-#if __has_cpp_attribute(fallthrough)
+#if __has_cpp_attribute(fallthrough)  &&  \
+    (!defined(__clang__)  ||  __clang_major__ > 7  ||  __cplusplus >= 201703L)
 #  define BM_FALLTHROUGH [[fallthrough]]
 #elif __has_cpp_attribute(gcc::fallthrough)
 #  define BM_FALLTHROUGH [[gcc::fallthrough]]


### PR DESCRIPTION
Don't try to use [[fallthrough]] under Clang 7 or older with C++14 or older;
in this situation, __has_cpp_attribute(fallthrough) succeeds but trying to
use the attribute fails with "error: use of the 'fallthrough' attribute is a
C++17 extension".