### PR TITLE
fixed CMake warnings related to CMP0054 policy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,9 +17,7 @@ include_directories("${PROJECT_SOURCE_DIR}/src")
 
 set (CMAKE_CXX_STANDARD 11)
 
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR
-    "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-
+if (CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     if ("${BMOPTFLAGS}" STREQUAL "BMSSE42OPT")
 	    set(bmoptf "-march=nehalem -O2 -msse4.2 -DBMSSE42OPT")
     elseif("${BMOPTFLAGS}" STREQUAL "BMAVX2OPT")
@@ -34,11 +32,10 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR
     SET( CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} -Wl,-lpthread")
     
 
-elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
+elseif (CMAKE_CXX_COMPILER_ID MATCHES "Intel")
     set(flags, "-tpp7 -march=core2 -restrict -DBM_HASRESTRICT -fno-fnalias -Wall")
     set(optflags, "-g0 -O3 -opt_report_fileopt.txt -opt_report_levelmax")
-elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-
+elseif (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
     if ("${BMOPTFLAGS}" STREQUAL "BMSSE42OPT")
 	set(bmoptf "-DBMSSE42OPT")
     elseif("${BMOPTFLAGS}" STREQUAL "BMAVX2OPT")


### PR DESCRIPTION
Hello. This PR fixes the warnings reproduced on CMake 3.17.0-rc1:
```
CMake Warning (dev) at CMakeLists.txt:20 (if):
  Policy CMP0054 is not set: Only interpret if() arguments as variables or
  keywords when unquoted.  Run "cmake --help-policy CMP0054" for policy
  details.  Use the cmake_policy command to set the policy and suppress this
  warning.

  Quoted variables like "MSVC" will no longer be dereferenced when the policy
  is set to NEW.  Since the policy is not set the OLD behavior will be used.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at CMakeLists.txt:37 (elseif):
  Policy CMP0054 is not set: Only interpret if() arguments as variables or
  keywords when unquoted.  Run "cmake --help-policy CMP0054" for policy
  details.  Use the cmake_policy command to set the policy and suppress this
  warning.

  Quoted variables like "MSVC" will no longer be dereferenced when the policy
  is set to NEW.  Since the policy is not set the OLD behavior will be used.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at CMakeLists.txt:40 (elseif):
  Policy CMP0054 is not set: Only interpret if() arguments as variables or
  keywords when unquoted.  Run "cmake --help-policy CMP0054" for policy
  details.  Use the cmake_policy command to set the policy and suppress this
  warning.

  Quoted variables like "MSVC" will no longer be dereferenced when the policy
  is set to NEW.  Since the policy is not set the OLD behavior will be used.
This warning is for project developers.  Use -Wno-dev to suppress it.
```

`STREQUAL` can be replaced with `MATCHES` because `MATCHES` was existing in CMake in 2.8.0 so it doesn't force you to increase version passed to `cmake_minimum_required` (https://cmake.org/cmake/help/v2.8.0/cmake.html#command:if).