### PR TITLE
make ex_buf__ into a thread local variable

### DIFF
--- a/lang-maps/libbm/src/libbm.cpp
+++ b/lang-maps/libbm/src/libbm.cpp
@@ -18,7 +18,12 @@ For more information please visit:  http://bitmagic.io
 
 #include "libbm.h"
 #include "try_throw_catch.h"
-static jmp_buf ex_buf__;
+
+#if defined(_MSC_VER)
+__declspec(thread) jmp_buf ex_buf__;
+#else
+__thread jmp_buf ex_buf__;
+#endif
 
 #define BM_NO_STL
 #define BM_NO_CXX11


### PR DESCRIPTION
Fixes the threading problem for Rust bindings in https://github.com/tlk00/BitMagic/issues/61#issuecomment-723659872.

I'm checking for MSVC and falling back to GCC/Clang syntax, should I add more checks/systems?