### PR TITLE
BM_FALLTHROUGH: Correctly conditionalize [[fallthrough]] under Clang.

### DIFF
--- a/src/bmdef.h
+++ b/src/bmdef.h
@@ -415,7 +415,7 @@ For more information please visit:  http://bitmagic.io
 #  define __has_attribute(x) 0
 #endif
 #if __has_cpp_attribute(fallthrough)  &&  \
-    (!defined(__clang__)  ||  __clang_major__ > 7  ||  __cplusplus >= 201703L)
+    (!defined(__clang__)  ||  (__clang_major__ > 7 && __cplusplus >= 201703L))
 #  define BM_FALLTHROUGH [[fallthrough]]
 #elif __has_cpp_attribute(gcc::fallthrough)
 #  define BM_FALLTHROUGH [[gcc::fallthrough]]


### PR DESCRIPTION
Require both Clang 7+ and C++17 or newer, rather than accepting either
on its own; otherwise, builds with strict flags (`-Wc++17-extensions`,
as implied by `-pedantic`) can trigger diagnostics.