### PR TITLE
bm*.h: Invoke BM_DECLARE_TEMP_BLOCK without a trailing semicolon.

### DIFF
--- a/src/bm.h
+++ b/src/bm.h
@@ -3299,7 +3299,7 @@ int bvector<Alloc>::compare(const bvector<Alloc>& bv) const BMNOEXCEPT
             
             if (arg_gap != gap)
             {
-                BM_DECLARE_TEMP_BLOCK(temp_blk);
+                BM_DECLARE_TEMP_BLOCK(temp_blk)
                 bm::wordop_t* blk1; bm::wordop_t* blk2;
 
                 if (gap)

--- a/src/bmbmatrix.h
+++ b/src/bmbmatrix.h
@@ -1134,7 +1134,7 @@ void basic_bmatrix<BV>::optimize(bm::word_t* temp_block,
     if (st)
         st->reset();
 
-    BM_DECLARE_TEMP_BLOCK(tb);
+    BM_DECLARE_TEMP_BLOCK(tb)
     if (!temp_block)
         temp_block = tb;
 

--- a/src/bmfunc.h
+++ b/src/bmfunc.h
@@ -8758,7 +8758,7 @@ bool block_find_first_diff(const bm::word_t* BMRESTRICT blk,
 
     if (arg_gap != gap)
     {
-        //BM_DECLARE_TEMP_BLOCK(temp_blk);
+        //BM_DECLARE_TEMP_BLOCK(temp_blk)
         bm::bit_block_t temp_blk;
         bm::word_t* blk1; bm::word_t* blk2;
 

--- a/src/bmsparsevec_parallel.h
+++ b/src/bmsparsevec_parallel.h
@@ -83,7 +83,7 @@ protected:
 
         typename bvector_type::statistics stbv;
         stbv.reset();
-        BM_DECLARE_TEMP_BLOCK(tb);
+        BM_DECLARE_TEMP_BLOCK(tb)
         bv->optimize(tb, opt_mode, &stbv);
 
         if (st)

--- a/src/bmxor.h
+++ b/src/bmxor.h
@@ -702,7 +702,7 @@ public:
         {
             for (size_type i = 0; i < sz; ++i)
                 ref_bvects_[i]->fill_alloc_digest(bv_blocks);
-            BM_DECLARE_TEMP_BLOCK(tb);
+            BM_DECLARE_TEMP_BLOCK(tb)
             bv_blocks.optimize(tb);
         }
     }
@@ -991,7 +991,7 @@ private:
     xor_scanner& operator=(const xor_scanner&) = delete;
 
 private:
-    BM_DECLARE_TEMP_BLOCK(xor_tmp_block_);
+    BM_DECLARE_TEMP_BLOCK(xor_tmp_block_)
 
     const bv_ref_vector_type*   ref_vect_ = 0; ///< ref.vect for XOR filter
     bv_blocks_vector_type       nb_blocks_vect_;   ///< pointers to temp blocks


### PR DESCRIPTION
It's defined to supply a semicolon itself, and roughly 80% of calls
overall rely on that characteristic, so go with the flow to avoid
breaking under `-Werror=pedantic`.