### PR TITLE
Avoid x86 SIMD detection in other platforms

### DIFF
--- a/lang-maps/libbm/src/libbm_impl.cpp
+++ b/lang-maps/libbm/src/libbm_impl.cpp
@@ -48,8 +48,10 @@ typedef bm::bvector<libbm::standard_allocator>::enumerator TBM_bvector_enumerato
 static
 unsigned x86_simd(void)
 {
-  unsigned eax, ebx, ecx, edx, flag = 0;
+  unsigned flag = 0;
+
 #ifdef BM_x86
+  unsigned eax, ebx, ecx, edx;
 #ifdef _MSC_VER
   int cpuid[4];
   __cpuid(cpuid, 1);
@@ -66,6 +68,7 @@ unsigned x86_simd(void)
   if (ebx>>5 &1) flag |= SIMD_AVX2;
   if (ebx>>16&1) flag |= SIMD_AVX512F;
 #endif // BM_x86
+
   return flag;
 }
 

--- a/lang-maps/libbm/src/libbm_impl.cpp
+++ b/lang-maps/libbm/src/libbm_impl.cpp
@@ -49,13 +49,14 @@ static
 unsigned x86_simd(void)
 {
   unsigned eax, ebx, ecx, edx, flag = 0;
+#ifdef BM_x86
 #ifdef _MSC_VER
   int cpuid[4];
   __cpuid(cpuid, 1);
   eax = cpuid[0], ebx = cpuid[1], ecx = cpuid[2], edx = cpuid[3];
 #else
   asm volatile("cpuid" : "=a" (eax), "=b" (ebx), "=c" (ecx), "=d" (edx) : "a" (1));
-#endif
+#endif // _MSC_VER
   if (edx>>25&1) flag |= SIMD_SSE;
   if (edx>>26&1) flag |= SIMD_SSE2;
   if (ecx>>0 &1) flag |= SIMD_SSE3;
@@ -64,6 +65,7 @@ unsigned x86_simd(void)
   if (ecx>>28&1) flag |= SIMD_AVX;
   if (ebx>>5 &1) flag |= SIMD_AVX2;
   if (ebx>>16&1) flag |= SIMD_AVX512F;
+#endif // BM_x86
   return flag;
 }
 


### PR DESCRIPTION
Fixes #65

I'm using the `BM_x86` flag defined in `bmdef.h` to limit `__cpuid` calls to `x86`, I think that is the proper solution?

With these changes I'm able to compile and test the [Rust bindings](https://github.com/luizirber/bitmagic-rs/pull/2) in aarch64/ppc64le/s390x platforms (tests are currently failing on s390x, but I don't have access to a machine to debug it :sweat_smile:)