### PR TITLE
bmutil.h: Simply go with <x86intrin.h> under (non-Windows) x86_64.

### DIFF
--- a/src/bmutil.h
+++ b/src/bmutil.h
@@ -30,11 +30,8 @@ For more information please visit:  http://bitmagic.io
 #else
     #if defined(_M_AMD64) || defined(_M_X64)
     #include <intrin.h>
-    #elif defined(BMSSE2OPT) || defined(BMSSE42OPT)
-    #include <emmintrin.h>
-    #elif defined(BMAVX2OPT)
-    #include <emmintrin.h>
-    #include <avx2intrin.h>
+    #elif defined(__x86_64__)
+    #include <x86intrin.h>
     #endif
 #endif
 


### PR DESCRIPTION
At least under macOS, it was possible to get errors that
_mm_popcnt_u{32,64} were undeclared; another branch would have failed
due to direct inclusion of <avx2intrin.h>, which insists on being
included via <immintrin.h>.  <x86intrin.h> is overkill, but still not
all that heavy, and avoids any such complications.