### PR TITLE
sse42_gap_test: Reinstate use of "inline" keyword.

### DIFF
--- a/src/bmsse4.h
+++ b/src/bmsse4.h
@@ -1453,6 +1453,7 @@ unsigned sse42_gap_bfind(const unsigned short* BMRESTRICT buf,
     @return test result
     @ingroup SSE4
 */
+inline
 unsigned sse42_gap_test(const unsigned short* BMRESTRICT buf, unsigned pos) BMNOEXCEPT
 {
     unsigned start = 1;
@@ -1510,6 +1511,7 @@ unsigned sse42_gap_test(const unsigned short* BMRESTRICT buf, unsigned pos) BMNO
 
 
 /*
+inline
 unsigned sse42_gap_test(const unsigned short* BMRESTRICT buf, unsigned pos) BMNOEXCEPT
 {
     unsigned start = 1;


### PR DESCRIPTION
Actual inlining would likely be impractical, but formally inviting the
possibility avoids multiple-definition errors in some scenarios.