### PR TITLE
deserializer<>::deserialize: Avoid warnings with assertions disabled.

### DIFF
--- a/src/bmserial.h
+++ b/src/bmserial.h
@@ -4539,7 +4539,7 @@ size_t deserializer<BV, DEC>::deserialize(bvector_type&        bv,
                 case 0: row_idx = dec.get_32(); break;
                 default: BM_ASSERT(0); break;
                 } // switch
-                bm::id64_t acc64 = x_ref_d64_ = dec.get_h64();
+                bm::id64_t acc64 = x_ref_d64_ = dec.get_h64(); (void) acc64;
                 BM_ASSERT(!xor_chain_size_);
                 xor_chain_size_ = dec.get_8();
                 BM_ASSERT(xor_chain_size_);


### PR DESCRIPTION
Ensure acc64 is always at least nominally used.

I used the same idiom as in f39ce89f.