### PR TITLE
Never follow BM_DECLARE_TEMP_BLOCK(...) with a semicolon.

### DIFF
--- a/src/bm.h
+++ b/src/bm.h
@@ -4387,7 +4387,7 @@ void bvector<Alloc>::import_block(const size_type* ids,
         #endif
         if (new_blocks_strat_ == BM_GAP) // optimization required
         {
-            BM_DECLARE_TEMP_BLOCK(temp_blk);
+            BM_DECLARE_TEMP_BLOCK(temp_blk)
             unsigned i0, j0;
             bm::get_block_coord(nblock, i0, j0);
             blockman_.optimize_block(i0, j0, blk, temp_blk, opt_compress, 0);

--- a/src/bmserial.h
+++ b/src/bmserial.h
@@ -627,7 +627,7 @@ protected:
                             block_idx_type expect_nb) BMNOEXCEPT;
 
 protected:
-    BM_DECLARE_TEMP_BLOCK(tb_wflags_); ///< temp flags for sub-block DR compression
+    BM_DECLARE_TEMP_BLOCK(tb_wflags_) ///< temp flags for sub-block DR compression
 
     bm::gap_word_t*   id_array_ = 0; ///< ptr to idx array for temp decode use
     unsigned*         sb_id_array_=0; ///< ptr to super-block idx array (temp)


### PR DESCRIPTION
It supplies one itself, and adding another can break builds with strict compilation settings (e.g., -Werror=pedantic), at least outside of a function.  Most invocations already lack extra semicolons.