### PR TITLE
Fix setting wrong bit in bitblock for import_block

### DIFF
--- a/src/bm.h
+++ b/src/bm.h
@@ -4374,7 +4374,7 @@ void bvector<Alloc>::import_block(const size_type* ids,
         {
             if (stop-start == 1)
             {
-                unsigned nbit = unsigned(ids[0] & bm::set_block_mask);
+                unsigned nbit = unsigned(ids[start] & bm::set_block_mask);
                 gap_block_set_no_ret(BMGAP_PTR(blk), true, nblock, nbit);
                 return;
             }


### PR DESCRIPTION
import_block uses the array's first element's bit position instead of the one specified by start, which can lead to the wrong bit being set in the bitblock in a case where a single bit is to be set for the block and the bit is not the first element of the array to be imported.

Minimal example to reproduce the issue:
```
bm::bvector<> bv;
bv.set(65540);
bv.optimize();
{
    bm::bvector<>::bulk_insert_iterator it(bv);
    *it = 0;
    *it = 65540;
}

assert(bv.count() == 2);
assert(bv.get_bit(0));
assert(bv.get_bit(65540));
```

This example produces a bvector with the bits 0, 65536 and 65540 set, instead of the expected 0 and 65540.