### PR TITLE
Fix typo breaking BM_NO_STL build

### DIFF
--- a/src/bmbuffer.h
+++ b/src/bmbuffer.h
@@ -226,7 +226,7 @@ public:
 #ifndef BM_NO_STL
     throw std::logic_error("BM: shrink ALLOC size >= capacity");
 #else
-    BM_THROW(BM_ERR_BADALLOC););
+    BM_THROW(BM_ERR_BADALLOC);
 #endif
     }
 


### PR DESCRIPTION
Hi, the no STL error case here has an extra ');' at the end that breaks the build with BM_NO_STL set in v8.0.1.